### PR TITLE
Upgrade Dockerfile_slurmctld to use Rocky Linux 9.3 as Dockerfile

### DIFF
--- a/Dockerfile_slurmctld
+++ b/Dockerfile_slurmctld
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM rockylinux:9.3
 
 # # Install basic tools for compiling
 # RUN yum groupinstall -y 'Development Tools'
@@ -48,11 +48,11 @@ ARG SLURM_TAG=slurm-21-08-6-1
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \
-    && yum makecache \
-    && yum -y update \
-    && yum -y install dnf-plugins-core \
-    && yum config-manager --set-enabled powertools \
-    && yum -y install \
+    && dnf makecache \
+    && dnf -y update \
+    && dnf -y install dnf-plugins-core \
+    && dnf config-manager --set-enabled crb \
+    && dnf -y install \
        wget \
        bzip2 \
        perl \
@@ -73,10 +73,10 @@ RUN set -ex \
        vim-enhanced \
        http-parser-devel \
        json-c-devel \
-    && yum clean all \
-    && rm -rf /var/cache/yum
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 
-RUN alternatives --set python /usr/bin/python3
+RUN alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 
 RUN pip3 install Cython nose
 
@@ -134,7 +134,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 ## ------- Setup SSH ------
-RUN yum -y update && yum install  openssh-server initscripts sudo -y
+RUN dnf -y update && dnf install  openssh-server initscripts sudo -y
 # Create a user “sshuser” and group “sshgroup”
 # RUN groupadd sshgroup && useradd -ms /bin/bash -g sshgroup sshuser
 # Create sshuser directory in home
@@ -154,9 +154,9 @@ RUN chown slurm:slurm /home/slurm
 RUN /usr/bin/ssh-keygen -A
 
 # ------- Install Singularity/Apptainer -------
-RUN yum install -y epel-release \
-    && yum install -y apptainer
-RUN yum install -y p7zip p7zip-plugins
+RUN dnf install -y epel-release \
+    && dnf install -y apptainer
+RUN dnf install -y p7zip p7zip-plugins
 
 # Expose docker port 22 for SSH
 EXPOSE 22


### PR DESCRIPTION
Changed rockylinux version of slurmctld to 9.3 as for other docker containers. To solve issues with permissions of shared munge.key, preventing the container to start.